### PR TITLE
fix: set duration when adding a new Exercise in workout_builder.dart

### DIFF
--- a/lib/workout_builder.dart
+++ b/lib/workout_builder.dart
@@ -103,7 +103,10 @@ class _BuilderPageState extends State<BuilderPage> {
   void _addExercise(int setIndex, bool isRest) {
     setState(() {
       _workout.sets[setIndex].exercises.add(
-          Exercise(name: isRest ? S.of(context).rest : S.of(context).exercise));
+          Exercise(
+              name: isRest ? S.of(context).rest : S.of(context).exercise,
+              duration: 30
+          ));
     });
   }
 


### PR DESCRIPTION
When adding a new exercise in the workout builder, my screen turned grey. The following exception was thrown:
```
======== Exception caught by widgets library =======================================================
The following NoSuchMethodError was thrown building:
The method '_addFromInteger' was called on null.
Receiver: null
Tried calling: _addFromInteger(0)

When the exception was thrown, this was the stack: 
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:51:5)
#1      int.+ (dart:core-patch/integers.dart:10:38)
#2      Set.duration.<anonymous closure> (package:just_another_workout_timer/workout.dart:81:47)
#3      List.forEach (dart:core-patch/growable_array.dart:313:8)
#4      Set.duration (package:just_another_workout_timer/workout.dart:81:15)
...
====================================================================================================
```
I was luckily able to reproduce the bug with an emulator and located it.
Phone: Huawei P20 Lite (Android 9)
Emulator: Pixel 3 API 28 (Android 9)
JAWT version: v1.4.0

Thank you for the useful app and kind regards!
oxq

