### PR TITLE
fix: set PrefService default values (closes #25)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,8 +11,14 @@ import 'tts_helper.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   GestureBinding.instance.resamplingEnabled = true;
-  PrefService.init(prefix: 'pref_').then((value) =>
-      Future.wait([TTSHelper.init(), SoundHelper.loadSounds()])
+  PrefService.init(prefix: 'pref_')
+      .then((value) => PrefService.setDefaultValues({
+            'wakelock': true,
+            'halftime': false,
+            'ticks': false,
+            'tts_next_announce': true
+          }))
+      .then((value) => Future.wait([TTSHelper.init(), SoundHelper.loadSounds()])
           .then((value) => runApp(JAWTApp())));
 }
 

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -51,7 +51,6 @@ class _SettingsPageState extends State<SettingsPage> {
           SwitchPreference(
             S.of(context).keepScreenAwake,
             'wakelock',
-            defaultVal: true,
           ),
           SwitchPreference(S.of(context).settingHalfway, 'halftime'),
           SwitchPreference(S.of(context).playTickEverySecond, 'ticks'),
@@ -102,7 +101,6 @@ class _SettingsPageState extends State<SettingsPage> {
           SwitchPreference(
             S.of(context).announceUpcomingExercise,
             'tts_next_announce',
-            defaultVal: true,
             desc: S.of(context).AnnounceUpcomingExerciseDesc,
           ),
           PreferenceTitle(S.of(context).licenses),


### PR DESCRIPTION
Sets default values for the SharedPreferences and therefore prevents null assertions.
This also makes setting the defaultVal of SwitchPreferences in settings_page.dart unnecessary.

Kind regards and thank you for the app!
oxq