### PR TITLE
feat: remove exit check in unnecessary situations in workout_runner

### DIFF
--- a/lib/workout_runner.dart
+++ b/lib/workout_runner.dart
@@ -512,6 +512,11 @@ class _WorkoutPageState extends State<WorkoutPage> {
         floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       ),
       onWillPop: () async {
+        // Just pop if the workout wasn't started yet or is already done
+        if(_timer == null || _workoutDone) {
+          return true;
+        }
+
         final value = await showDialog<bool>(
             context: context,
             builder: (context) => AlertDialog(


### PR DESCRIPTION
I removed the exit check in the workout_runner in the following situations:
- the workout wasn't started yet
- the workout is completed
The exit check now only shows in the following situations:
- the workout is running
- the workout is paused

In my opinion this is a more intuitive handling because the user now only is asked when he would abort his ongoing workout by exiting.

Kind regards
mschmidm