### PR TITLE
fix: don't rebuild BuilderPage after text input (closes #39)

### DIFF
--- a/lib/workout_builder.dart
+++ b/lib/workout_builder.dart
@@ -268,9 +268,7 @@ class _BuilderPageState extends State<BuilderPage> {
                   ),
                   onChanged: (text) {
                     _workout.sets[setIndex].exercises[exIndex].name = text;
-                    setState(() {
-                      _dirty = true;
-                    });
+                    _dirty = true;
                   },
                 )),
             Column(


### PR DESCRIPTION
The loss of focus (#39) is caused by rebuilding the BuilderPage in onChanged() by calling setState(). This call can be removed without affecting the check of unsaved changes.

Kind regards and thank you for the app!
mschmidm