### PR TITLE
Named Sets and toggle for Set exercise visiblity

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -19,6 +19,7 @@
     "duplicate": "Duplicate",
     "durationLeft": "{timeLeft} of {timeTotal} left",
     "durationWithTime": "Duration: {formattedTime}",
+    "editSetName" : "Edit set name",
     "editWorkout": "Edit workout",
     "enterWorkoutName": "Please enter a name for the workout!",
     "exercise": "Exercise",

--- a/lib/layouts/workout_builder.dart
+++ b/lib/layouts/workout_builder.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:prompt_dialog/prompt_dialog.dart';
 import 'package:uuid/uuid.dart';
 
 import '../generated/l10n.dart';
@@ -149,6 +150,20 @@ class BuilderPageState extends State<BuilderPage> {
     });
   }
 
+  void _editSetName(int setIndex) async {
+    var existingName = _workout.sets[setIndex].name ?? "";
+    var newName = await prompt(
+        context,
+        initialValue: existingName,
+        maxLength: 15);
+    if (newName != null && newName != existingName) {
+      setState(() {
+        _workout.sets[setIndex].name = newName.isEmpty ? null : newName;
+        _dirty = true;
+      });
+    }
+  }
+
   Widget _buildSetList() => ReorderableListView(
         onReorder: (oldIndex, newIndex) {
           if (oldIndex < newIndex) {
@@ -186,10 +201,18 @@ class BuilderPageState extends State<BuilderPage> {
                   Expanded(
                     child: ListTile(
                       title: Text(
+                        set.name ??
                         S.of(context).setIndex(_workout.sets.indexOf(set) + 1),
                       ),
                       subtitle: Text(Utils.formatSeconds(set.duration)),
                     ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.edit),
+                    tooltip: S.of(context).editSetName,
+                    onPressed: () {
+                      _editSetName(index);
+                    },
                   ),
                   Text(S.of(context).repetitions),
                   NumberStepper(

--- a/lib/layouts/workout_builder.dart
+++ b/lib/layouts/workout_builder.dart
@@ -254,12 +254,20 @@ class BuilderPageState extends State<BuilderPage> {
                   Row(
                     children: [
                       IconButton(
-                        icon: const Icon(Icons.delete),
-                        tooltip: S.of(context).deleteSet,
+                        icon: Icon(set.hidden ? Icons.visibility : Icons.visibility_off),
                         onPressed: () {
-                          _deleteSet(index);
+                          setState(() {
+                            set.hidden = !set.hidden;
+                            _dirty = true;
+                          });
                         },
                       ),
+                      IconButton(
+                          icon: const Icon(Icons.delete),
+                          tooltip: S.of(context).deleteSet,
+                          onPressed: () {
+                            _deleteSet(index);
+                          }),
                       IconButton(
                         icon: const Icon(Icons.copy),
                         tooltip: S.of(context).duplicate,
@@ -286,7 +294,7 @@ class BuilderPageState extends State<BuilderPage> {
             _workout.sets[setIndex].exercises.insert(newIndex, ex);
           });
         },
-        children: set.exercises
+        children: set.hidden ? [] : set.exercises
             .asMap()
             .keys
             .map(

--- a/lib/layouts/workout_builder.dart
+++ b/lib/layouts/workout_builder.dart
@@ -57,7 +57,7 @@ class BuilderPageState extends State<BuilderPage> {
     var newSet = Set.fromJson(_workout.sets[index].toJson());
     newSet.id = const Uuid().v4();
     setState(() {
-      _workout.sets.insert(index, newSet);
+      _workout.sets.insert(index + 1, newSet);
       _dirty = true;
     });
   }

--- a/lib/layouts/workout_builder.dart
+++ b/lib/layouts/workout_builder.dart
@@ -267,7 +267,8 @@ class BuilderPageState extends State<BuilderPage> {
                           tooltip: S.of(context).deleteSet,
                           onPressed: () {
                             _deleteSet(index);
-                          }),
+                          }
+                      ),
                       IconButton(
                         icon: const Icon(Icons.copy),
                         tooltip: S.of(context).duplicate,

--- a/lib/layouts/workout_builder.dart
+++ b/lib/layouts/workout_builder.dart
@@ -203,16 +203,15 @@ class BuilderPageState extends State<BuilderPage> {
                       title: Text(
                         set.name ??
                         S.of(context).setIndex(_workout.sets.indexOf(set) + 1),
+                        style: const TextStyle(
+                          decoration: TextDecoration.underline,
+                        ),
                       ),
                       subtitle: Text(Utils.formatSeconds(set.duration)),
+                      onLongPress: () {
+                        _editSetName(index);
+                      },
                     ),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.edit),
-                    tooltip: S.of(context).editSetName,
-                    onPressed: () {
-                      _editSetName(index);
-                    },
                   ),
                   Text(S.of(context).repetitions),
                   NumberStepper(

--- a/lib/layouts/workout_runner.dart
+++ b/lib/layouts/workout_runner.dart
@@ -147,92 +147,79 @@ class WorkoutPageState extends State<WorkoutPageContent> {
               // left side of footer
               Expanded(
                 child: ListTile(
-                  title: Text(
-                    S.of(context).exerciseOf(
-                          timetable.currentSet.exercises
-                                  .indexOf(timetable.currentExercise) +
-                              1 +
-                              (timetable.currentReps *
-                                  timetable.currentSet.exercises.length),
-                          timetable.currentSet.exercises.length *
-                              timetable.currentSet.repetitions,
-                        ),
-                  ),
-                  subtitle: Text(
-                    S.of(context).repOf(
-                          timetable.currentReps + 1,
-                          timetable.currentSet.repetitions,
-                        ),
-                  ),
-                ),
-              ),
+                title: Text(S.of(context).exerciseOf(
+                    timetable.currentSet.exercises
+                            .indexOf(timetable.currentExercise) +
+                        1 +
+                        (timetable.currentReps *
+                            timetable.currentSet.exercises.length),
+                    timetable.currentSet.exercises.length *
+                        timetable.currentSet.repetitions)),
+                subtitle: Text(S.of(context).repOf(timetable.currentReps + 1,
+                    timetable.currentSet.repetitions)),
+              )),
               // right side of footer
               Expanded(
-                child: ListTile(
-                  title: Text(
-                    S.of(context).setOf(
-                          _workout.sets.indexOf(timetable.currentSet) + 1,
-                          _workout.sets.length,
-                        ),
-                    textAlign: TextAlign.end,
-                  ),
-                  subtitle: Text(
-                    S.of(context).durationLeft(
-                          Utils.formatSeconds(
-                            _workout.duration - timetable.currentSecond + 10,
-                          ),
-                          Utils.formatSeconds(_workout.duration + 10),
-                        ),
-                    textAlign: TextAlign.end,
-                  ),
+                  child: ListTile(
+                title: Text(
+                  S.of(context).setOf(
+                      _workout.sets.indexOf(timetable.currentSet) + 1,
+                      _workout.sets.length),
+                  textAlign: TextAlign.end,
                 ),
-              ),
+                subtitle: Text(
+                  S.of(context).durationLeft(
+                      Utils.formatSeconds(
+                          _workout.duration - timetable.currentSecond + 10),
+                      Utils.formatSeconds(_workout.duration + 10)),
+                  textAlign: TextAlign.end,
+                ),
+              ))
             ],
-          ),
-        ),
-        body: Column(
-          children: [
-            // top card with current exercise
-            Card(
-              child: Center(
-                child: Column(
-                  children: [
-                    Text(
-                      '${S.of(context).setIndex(_workout.sets.indexOf(timetable.currentSet) + 1)} - ${Utils.formatSeconds(timetable.remainingSeconds)}',
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(
-                        fontSize: 48,
-                        fontWeight: FontWeight.bold,
+          )),
+          body: Column(
+            children: [
+              // top card with current exercise
+              Card(
+                child: Center(
+                  child: Column(
+                    children: [
+                      Text(
+                        timetable.currentSet.name ?? S.of(context).setIndex(_workout.sets.indexOf(timetable.currentSet) + 1),
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                            fontSize: 40, fontWeight: FontWeight.bold),
                       ),
-                    ),
-                    LinearProgressIndicator(
-                      value: timetable.remainingSeconds /
-                          (timetable.currentSecond < 10
-                              ? 10
-                              : timetable.currentExercise.duration),
-                      minHeight: 6,
-                      valueColor: AlwaysStoppedAnimation<Color>(
-                        Theme.of(context).colorScheme.secondary,
+                      Text(
+                        Utils.formatSeconds(timetable.remainingSeconds),
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                            fontSize: 48, fontWeight: FontWeight.bold),
                       ),
-                    ),
-                    Text(
-                      timetable.currentExercise.name,
-                      style: const TextStyle(
-                        fontSize: 48,
-                        fontWeight: FontWeight.bold,
+                      LinearProgressIndicator(
+                        value: timetable.remainingSeconds /
+                            (timetable.currentSecond < 10
+                                ? 10
+                                : timetable.currentExercise.duration),
+                        minHeight: 6,
+                        valueColor: AlwaysStoppedAnimation<Color>(
+                            Theme.of(context).colorScheme.secondary),
                       ),
-                      textAlign: TextAlign.center,
-                    ),
-                    timetable.nextExercise != null
-                        ? Text(
-                            S.of(context).nextExercise(
-                                  timetable.nextExercise?.name ?? '',
-                                ),
-                            style: const TextStyle(fontSize: 24),
-                            textAlign: TextAlign.center,
-                          )
-                        : Container(),
-                  ],
+                      Text(
+                        timetable.currentExercise.name,
+                        style: const TextStyle(
+                            fontSize: 48, fontWeight: FontWeight.bold),
+                        textAlign: TextAlign.center,
+                      ),
+                      timetable.nextExercise != null
+                          ? Text(
+                              S.of(context).nextExercise(
+                                  timetable.nextExercise?.name ?? ''),
+                              style: const TextStyle(fontSize: 24),
+                              textAlign: TextAlign.center,
+                            )
+                          : Container(),
+                    ],
                 ),
               ),
             ),

--- a/lib/layouts/workout_runner.dart
+++ b/lib/layouts/workout_runner.dart
@@ -147,79 +147,101 @@ class WorkoutPageState extends State<WorkoutPageContent> {
               // left side of footer
               Expanded(
                 child: ListTile(
-                title: Text(S.of(context).exerciseOf(
-                    timetable.currentSet.exercises
-                            .indexOf(timetable.currentExercise) +
-                        1 +
-                        (timetable.currentReps *
-                            timetable.currentSet.exercises.length),
-                    timetable.currentSet.exercises.length *
-                        timetable.currentSet.repetitions)),
-                subtitle: Text(S.of(context).repOf(timetable.currentReps + 1,
-                    timetable.currentSet.repetitions)),
-              )),
+                  title: Text(
+                    S.of(context).exerciseOf(
+                          timetable.currentSet.exercises
+                                  .indexOf(timetable.currentExercise) +
+                              1 +
+                              (timetable.currentReps *
+                                  timetable.currentSet.exercises.length),
+                          timetable.currentSet.exercises.length *
+                              timetable.currentSet.repetitions,
+                        ),
+                  ),
+                  subtitle: Text(
+                    S.of(context).repOf(
+                          timetable.currentReps + 1,
+                          timetable.currentSet.repetitions,
+                        ),
+                  ),
+                ),
+              ),
+
               // right side of footer
               Expanded(
-                  child: ListTile(
-                title: Text(
-                  S.of(context).setOf(
-                      _workout.sets.indexOf(timetable.currentSet) + 1,
-                      _workout.sets.length),
-                  textAlign: TextAlign.end,
+                child: ListTile(
+                  title: Text(
+                    S.of(context).setOf(
+                          _workout.sets.indexOf(timetable.currentSet) + 1,
+                          _workout.sets.length,
+                        ),
+                    textAlign: TextAlign.end,
+                  ),
+                  subtitle: Text(
+                    S.of(context).durationLeft(
+                          Utils.formatSeconds(
+                            _workout.duration - timetable.currentSecond + 10,
+                          ),
+                          Utils.formatSeconds(_workout.duration + 10),
+                        ),
+                    textAlign: TextAlign.end,
+                  ),
                 ),
-                subtitle: Text(
-                  S.of(context).durationLeft(
-                      Utils.formatSeconds(
-                          _workout.duration - timetable.currentSecond + 10),
-                      Utils.formatSeconds(_workout.duration + 10)),
-                  textAlign: TextAlign.end,
-                ),
-              ))
+              ),
             ],
-          )),
-          body: Column(
-            children: [
-              // top card with current exercise
-              Card(
-                child: Center(
-                  child: Column(
-                    children: [
-                      Text(
-                        timetable.currentSet.name ?? S.of(context).setIndex(_workout.sets.indexOf(timetable.currentSet) + 1),
-                        textAlign: TextAlign.center,
-                        style: const TextStyle(
-                            fontSize: 40, fontWeight: FontWeight.bold),
+          ),
+        ),
+        body: Column(
+          children: [
+            // top card with current exercise
+            Card(
+              child: Center(
+                child: Column(
+                  children: [
+                    Text(
+                      timetable.currentSet.name ?? S.of(context).setIndex(_workout.sets.indexOf(timetable.currentSet) + 1),
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        fontSize: 40,
+                        fontWeight: FontWeight.bold,
+                        ),
                       ),
-                      Text(
-                        Utils.formatSeconds(timetable.remainingSeconds),
-                        textAlign: TextAlign.center,
-                        style: const TextStyle(
-                            fontSize: 48, fontWeight: FontWeight.bold),
+                    Text(
+                      Utils.formatSeconds(timetable.remainingSeconds),
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        fontSize: 48,
+                        fontWeight: FontWeight.bold,
                       ),
-                      LinearProgressIndicator(
-                        value: timetable.remainingSeconds /
-                            (timetable.currentSecond < 10
-                                ? 10
-                                : timetable.currentExercise.duration),
-                        minHeight: 6,
-                        valueColor: AlwaysStoppedAnimation<Color>(
-                            Theme.of(context).colorScheme.secondary),
+                    ),
+                    LinearProgressIndicator(
+                      value: timetable.remainingSeconds /
+                          (timetable.currentSecond < 10
+                              ? 10
+                              : timetable.currentExercise.duration),
+                      minHeight: 6,
+                      valueColor: AlwaysStoppedAnimation<Color>(
+                        Theme.of(context).colorScheme.secondary,
                       ),
-                      Text(
-                        timetable.currentExercise.name,
-                        style: const TextStyle(
-                            fontSize: 48, fontWeight: FontWeight.bold),
-                        textAlign: TextAlign.center,
+                    ),
+                    Text(
+                      timetable.currentExercise.name,
+                      style: const TextStyle(
+                        fontSize: 48,
+                        fontWeight: FontWeight.bold,
                       ),
-                      timetable.nextExercise != null
-                          ? Text(
-                              S.of(context).nextExercise(
-                                  timetable.nextExercise?.name ?? ''),
-                              style: const TextStyle(fontSize: 24),
-                              textAlign: TextAlign.center,
-                            )
-                          : Container(),
-                    ],
+                      textAlign: TextAlign.center,
+                    ),
+                    timetable.nextExercise != null
+                        ? Text(
+                            S.of(context).nextExercise(
+                                  timetable.nextExercise?.name ?? '',
+                                ),
+                            style: const TextStyle(fontSize: 24),
+                            textAlign: TextAlign.center,
+                          )
+                        : Container(),
+                  ],
                 ),
               ),
             ),

--- a/lib/utils/workout.dart
+++ b/lib/utils/workout.dart
@@ -51,6 +51,7 @@ class Set {
     String? id,
     this.repetitions = 1,
     List<Exercise>? exercises,
+    this.name
   }) {
     this.id = id ?? const Uuid().v4();
     this.exercises = exercises ?? [Exercise()];
@@ -58,6 +59,9 @@ class Set {
 
   @JsonKey(required: true)
   int repetitions;
+
+  @JsonKey()
+  late String? name;
 
   @JsonKey()
   late String id;

--- a/lib/utils/workout.dart
+++ b/lib/utils/workout.dart
@@ -51,7 +51,8 @@ class Set {
     String? id,
     this.repetitions = 1,
     List<Exercise>? exercises,
-    this.name
+    this.name,
+    this.hidden = false,
   }) {
     this.id = id ?? const Uuid().v4();
     this.exercises = exercises ?? [Exercise()];
@@ -68,6 +69,8 @@ class Set {
 
   @JsonKey(required: true)
   late List<Exercise> exercises;
+
+  bool hidden;
 
   int get duration {
     var duration = 0;

--- a/lib/workout.g.dart
+++ b/lib/workout.g.dart
@@ -39,6 +39,7 @@ Set _$SetFromJson(Map<String, dynamic> json) {
     exercises: (json['exercises'] as List<dynamic>?)
         ?.map((e) => Exercise.fromJson(e as Map<String, dynamic>))
         .toList(),
+    name: json['name'] as String?
   );
 }
 
@@ -46,6 +47,7 @@ Map<String, dynamic> _$SetToJson(Set instance) => <String, dynamic>{
       'repetitions': instance.repetitions,
       'id': instance.id,
       'exercises': instance.exercises.map((e) => e.toJson()).toList(),
+      'name' : instance.name
     };
 
 Exercise _$ExerciseFromJson(Map<String, dynamic> json) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   path_provider: '^2.1.3'
   pref: '^2.8.0'
   prefs: '^4.1.0+3'
+  prompt_dialog: '^1.0.16'
   provider: '^6.1.2'
   scrollable_positioned_list: '^0.3.8'
   share_plus: '^9.0.0'


### PR DESCRIPTION
A couple small quality of life changes as I learn dart and flutter.

1) Add a way to give a name to a set. Currently this is triggered via a long-press on the ListTile which contains the set name using a flutter prompt dialog. I considered making the set name a live text field, like the workout name, but the set editing interface is already busy and I didn't want to add something else that a user could accidentally click on. I don't love that the edit facility is now not easily discoverable, though. I played with adding an edit button but no matter where I put it, it really messed with the layout of the ListTile. Open to other and better suggestions for this.

Set names are saved to json and show up in the workout runner.  I limited them to 15 characters, but even at that length, they can push the timer in the workout builder onto a new line, so I just permanent split the set name and the timer onto separate lines. I also dropped the font size slightly on the set name.

2) Add a way to hide the exercise list for a set in the workout builder. Makes it much easier to re-ordered sets or to just concentrate on the current set being built. Since this is just UI sugar, I did not persist it to JSON. I also purposely did not copy it when duplicating a set. This way, you can use a workflow where you make a set, collapse its exercises, duplicate it, and then immediately be ready to edit the new set. This also necessitated fixing a small bug where a duplicated set was being inserted before the current set. It wasn't noticeable before sets could be collapsed, but it is now.