### PR TITLE
Add a tiny bottom nav bar to the home page

### DIFF
--- a/lib/layouts/home_page.dart
+++ b/lib/layouts/home_page.dart
@@ -207,5 +207,10 @@ class HomePageState extends State<HomePage> {
           tooltip: S.of(context).addWorkout,
           child: const Icon(Icons.add),
         ),
+        // Empty App Bar prevents drawing under nav buttons.
+        bottomNavigationBar: const BottomAppBar(
+          elevation : 1,
+          height: 1,
+        )
       );
 }


### PR DESCRIPTION
This is a fix for #132 to keep the list of workouts from drawing under the nav buttons