### PR TITLE
Feature/spinner control

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
   <h3 align="center">Just Another Workout Timer</h3>
 
+  
   <p align="center">
     A simple timer for your workouts, built with Flutter!
     <br />

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -57,6 +57,7 @@
     "settingHalfway": "Play sound or announcement halfway during exercise",
     "settings": "Settings",
     "soundOutput": "Sound output",
+    "spinnerStep": "Editor time granularity",
     "startWorkout": "Start workout",
     "title": "Just Another Workout Timer",
     "tts": "Text-to-Speech (TTS)",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -59,6 +59,7 @@
     "soundOutput": "Sound output",
     "spinnerStep": "Editor time granularity",
     "startWorkout": "Start workout",
+    "tapToEdit": "Tap to edit",
     "title": "Just Another Workout Timer",
     "tts": "Text-to-Speech (TTS)",
     "ttsLang": "TTS Language",

--- a/lib/layouts/settings_page.dart
+++ b/lib/layouts/settings_page.dart
@@ -102,6 +102,25 @@ class SettingsPageState extends State<SettingsPage> {
             subtitle: Text(S.of(context).expanded_setlist_info),
             pref: 'expanded_setlist',
           ),
+          PrefDropdown<int>(
+            title: Text(S.of(context).spinnerStep),
+            pref: 'spinner_step',
+            items: [
+              DropdownMenuItem(
+                value: 5,
+                child: Text("5 ${S.of(context).seconds}"),
+              ),
+              DropdownMenuItem(
+                value: 10,
+                child: Text("10 ${S.of(context).seconds}"),
+              ),
+              DropdownMenuItem(
+                value: 15,
+                child: Text("15 ${S.of(context).seconds}"),
+              ),
+            ],
+          ),
+
           PrefTitle(
             title: Text(
               S.of(context).backup,

--- a/lib/layouts/settings_page.dart
+++ b/lib/layouts/settings_page.dart
@@ -102,6 +102,12 @@ class SettingsPageState extends State<SettingsPage> {
             subtitle: Text(S.of(context).expanded_setlist_info),
             pref: 'expanded_setlist',
           ),
+
+          PrefTitle(
+            title: Text(
+              S.of(context).editWorkout,
+            ),
+          ),
           PrefDropdown<int>(
             title: Text(S.of(context).spinnerStep),
             pref: 'spinner_step',
@@ -119,6 +125,10 @@ class SettingsPageState extends State<SettingsPage> {
                 child: Text("15 ${S.of(context).seconds}"),
               ),
             ],
+          ),
+          PrefSwitch(
+            title: Text(S.of(context).tapToEdit),
+            pref: 'tap_to_edit',
           ),
 
           PrefTitle(

--- a/lib/layouts/workout_builder.dart
+++ b/lib/layouts/workout_builder.dart
@@ -199,6 +199,7 @@ class BuilderPageState extends State<BuilderPage> {
                     largeSteps: false,
                     step: 1,
                     formatNumber: false,
+                    tapToEdit: false,
                     value: set.repetitions,
                     valueChanged: (repetitions) {
                       setState(() {
@@ -341,6 +342,7 @@ class BuilderPageState extends State<BuilderPage> {
                     largeSteps: true,
                     step: Prefs.getInt('spinner_step', 10) ,
                     formatNumber: true,
+                    tapToEdit: Prefs.getBool('tap_to_edit', false),
                     value: _workout.sets[setIndex].exercises[exIndex].duration,
                     valueChanged: (duration) {
                       setState(() {

--- a/lib/layouts/workout_builder.dart
+++ b/lib/layouts/workout_builder.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:prefs/prefs.dart';
 import 'package:uuid/uuid.dart';
 
 import '../generated/l10n.dart';
@@ -196,6 +197,7 @@ class BuilderPageState extends State<BuilderPage> {
                     lowerLimit: 1,
                     upperLimit: 99,
                     largeSteps: false,
+                    step: 1,
                     formatNumber: false,
                     value: set.repetitions,
                     valueChanged: (repetitions) {
@@ -337,6 +339,7 @@ class BuilderPageState extends State<BuilderPage> {
                     lowerLimit: 0,
                     upperLimit: 10800,
                     largeSteps: true,
+                    step: Prefs.getInt('spinner_step', 10) ,
                     formatNumber: true,
                     value: _workout.sets[setIndex].exercises[exIndex].duration,
                     valueChanged: (duration) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,7 @@ void main() async {
       'tts_next_announce': true,
       'sound': 'tts',
       'expanded_setlist': false,
+      'spinner_step': 10,
     },
   ).then(
     (service) => Future.wait([

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ void main() async {
       'sound': 'tts',
       'expanded_setlist': false,
       'spinner_step': 10,
+      'tap_to_edit' : false,
     },
   ).then(
     (service) => Future.wait([

--- a/lib/utils/number_stepper.dart
+++ b/lib/utils/number_stepper.dart
@@ -16,6 +16,7 @@ class NumberStepper extends StatefulWidget {
     required this.valueChanged,
     required this.formatNumber,
     required this.largeSteps,
+    required this.step,
   });
 
   final int lowerLimit;
@@ -24,7 +25,10 @@ class NumberStepper extends StatefulWidget {
   int value;
   final ValueChanged<int> valueChanged;
   final bool formatNumber;
+  // if false, shows a number with plus/minus buttons.
+  // if true, shows the spinner.
   final bool largeSteps;
+  final int step;
 
   @override
   CustomStepperState createState() => CustomStepperState();
@@ -47,12 +51,16 @@ class CustomStepperState extends State<NumberStepper> {
   }
 
   Widget _editableTextField() {
-    if (_isEditingText) {
+    var isSpinnerValid = widget.value % widget.step == 0;
+
+    if (_isEditingText || !isSpinnerValid) {
       _editingController.value =
           TextEditingValue(text: widget.value.toString());
-      return Center(
+      return Container(
+        width: 122,
+        alignment: Alignment.centerRight,
         child: SizedBox(
-          width: 112,
+          width: 75,
           child: TextField(
             maxLines: 1,
             maxLengthEnforcement: MaxLengthEnforcement.enforced,
@@ -75,9 +83,13 @@ class CustomStepperState extends State<NumberStepper> {
                 }
               });
             },
-            autofocus: true,
+            // Only autofocus if we're text editing, not for isSpinnerValid
+            autofocus: _isEditingText,
             controller: _editingController,
-            decoration: InputDecoration(suffixText: S.of(context).seconds),
+            decoration: InputDecoration(
+              helperText: S.of(context).seconds,
+              helperStyle: const TextStyle(fontSize: 14),
+            ),
           ),
         ),
       );
@@ -92,7 +104,7 @@ class CustomStepperState extends State<NumberStepper> {
         itemHeight: 32,
         value: widget.value,
         minValue: widget.lowerLimit,
-        step: 10,
+        step: widget.step,
         itemCount: 3,
         haptics: true,
         zeroPad: false,


### PR DESCRIPTION
Add a preference for Spinner granularity which can be set to 5, 10, or 15 seconds.

If a time value is entered for an exercise that cannot be shown in the spinner, then it will automatically show the text edit instead of the spinner. Changing the value to a valid spinner value will call the spinner to reappear. This addresses bug 
https://github.com/blockbasti/just_another_workout_timer/issues/197

Add a preference for tap to edit. When it is activated, spinners have to be tapped to cause them to work instead of always being active. you can also long press to enter the manual text edit mode.

